### PR TITLE
Add dedicated menu page

### DIFF
--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,0 +1,24 @@
+/** @format */
+
+"use client";
+import React from "react";
+import ProductCard from "@/components/shared/ProductCard";
+import { MOCK_PRODUCTS } from "@/constants/components";
+
+export default function MenuPage() {
+  return (
+    <div className="container mx-auto px-4 md:px-6 py-12">
+      <h1 className="text-3xl font-bold text-center mb-6 text-gray-900">
+        Daftar Menu
+      </h1>
+      <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto">
+        Pilih pempek favorit Anda dan tambahkan ke keranjang.
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+        {MOCK_PRODUCTS.map((product) => (
+          <ProductCard key={product.id} product={product} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/constants/components.ts
+++ b/src/constants/components.ts
@@ -6,7 +6,7 @@ export const APP_NAME = 'PempekYo';
 
 export const NAV_LINKS: NavLink[] = [
   { href: '/', label: 'Beranda' },
-  { href: '/#menu', label: 'Menu' }, // Assuming menu is a section on homepage
+  { href: '/menu', label: 'Menu' },
   { href: '/#tentang-kami', label: 'Tentang Kami' }, // Assuming about is a section
   { href: '/#kontak', label: 'Kontak' }, // Assuming contact is a section
 ];


### PR DESCRIPTION
## Summary
- add `/menu` page to list all products with add-to-cart buttons
- link Navbar menu item to the new page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c65684dbc83229f6649a45a37cdf3