### PR TITLE
feat(auth): add user role

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -13,6 +13,7 @@ export interface RegisterDetails {
   email: string;
   password: string;
   name: string;
+  role?: 'admin' | 'customer';
   [key: string]: unknown;
 }
 
@@ -30,6 +31,7 @@ export async function register(
       ...details,
       name: details.name,
       email: details.email,
+      role: details.role ?? 'customer',
     });
     return cred;
   } catch (e) {

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -57,6 +57,7 @@ export const useAuthStore = create<AuthState>()(
             id: cred.user.uid,
             email: cred.user.email ?? credentials.email,
             name: data?.name ?? '',
+            role: data?.role ?? 'customer',
           };
 
           set({ user, isLoggedIn: true, isLoading: false });
@@ -82,6 +83,7 @@ export const useAuthStore = create<AuthState>()(
             id: cred.user.uid,
             email: cred.user.email ?? '',
             name: data?.name ?? '',
+            role: data?.role ?? 'customer',
           };
 
           set({ user, isLoggedIn: true, isLoading: false });
@@ -108,6 +110,7 @@ export const useAuthStore = create<AuthState>()(
             id: cred.user.uid,
             email: details.email,
             name: details.name,
+            role: details.role ?? 'customer',
           };
 
           set({ user, isLoggedIn: true, isLoading: false });

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -30,7 +30,7 @@ export interface User {
   id: string;
   name?: string;
   email: string;
-  // Add other user fields as needed
+  role: 'admin' | 'customer';
 }
 
 export interface ShippingInfo {


### PR DESCRIPTION
## Summary
- add `role` field to user model
- store role during registration with default `customer`
- load user role from Firestore into auth state

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f0e55966c832293d80e6d8d6eb794