### PR TITLE
feat: add admin dashboard skeleton

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Link from "next/link";
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen">
+      <aside className="w-64 bg-gray-800 text-white p-4 space-y-4">
+        <h2 className="text-xl font-bold">Admin</h2>
+        <nav className="flex flex-col space-y-2">
+          <Link href="/admin/products" className="p-2 rounded hover:bg-gray-700">
+            Products
+          </Link>
+          <Link href="/admin/orders" className="p-2 rounded hover:bg-gray-700">
+            Orders
+          </Link>
+        </nav>
+      </aside>
+      <div className="flex-1 flex flex-col">
+        <header className="h-16 border-b px-4 flex items-center justify-between bg-white">
+          <h1 className="text-lg font-semibold">Dashboard</h1>
+        </header>
+        <main className="flex-1 p-4">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function AdminOrdersPage() {
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Orders</h2>
+      <p>View and manage orders here.</p>
+    </div>
+  );
+}

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function AdminProductsPage() {
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Products</h2>
+      <p>Manage your products here.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add admin layout with sidebar and topbar
- scaffold products and orders pages for admin dashboard

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f16af49048322930642025f83cd28