### PR TITLE
feat: add Firestore product CRUD and admin management

### DIFF
--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -1,10 +1,144 @@
-import React from "react";
+"use client";
+import React, { useEffect, useState } from "react";
+import type { Product } from "@/types/components";
+import {
+  addProduct,
+  deleteProduct,
+  getProducts,
+  updateProduct,
+} from "@/lib/products";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 export default function AdminProductsPage() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [form, setForm] = useState({
+    id: "",
+    name: "",
+    description: "",
+    price: "",
+    imageUrl: "",
+  });
+
+  const load = async () => {
+    const data = await getProducts();
+    setProducts(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { id, name, description, price, imageUrl } = form;
+    const payload = {
+      name,
+      description,
+      price: Number(price),
+      imageUrl,
+    };
+
+    if (id) {
+      await updateProduct(id, payload);
+    } else {
+      await addProduct(payload);
+    }
+
+    setForm({ id: "", name: "", description: "", price: "", imageUrl: "" });
+    load();
+  };
+
+  const handleEdit = (product: Product) => {
+    setForm({
+      id: product.id,
+      name: product.name,
+      description: product.description,
+      price: String(product.price),
+      imageUrl: product.imageUrl,
+    });
+  };
+
+  const handleDelete = async (id: string) => {
+    await deleteProduct(id);
+    load();
+  };
+
   return (
     <div>
       <h2 className="text-2xl font-bold mb-4">Products</h2>
-      <p>Manage your products here.</p>
+      <form onSubmit={handleSubmit} className="space-y-2 mb-6 max-w-md">
+        <Input
+          placeholder="Name"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          required
+        />
+        <Input
+          placeholder="Description"
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+          required
+        />
+        <Input
+          type="number"
+          placeholder="Price"
+          value={form.price}
+          onChange={(e) => setForm({ ...form, price: e.target.value })}
+          required
+        />
+        <Input
+          placeholder="Image URL"
+          value={form.imageUrl}
+          onChange={(e) => setForm({ ...form, imageUrl: e.target.value })}
+          required
+        />
+        <div className="space-x-2">
+          <Button type="submit">
+            {form.id ? "Update" : "Add"} Product
+          </Button>
+          {form.id && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() =>
+                setForm({ id: "", name: "", description: "", price: "", imageUrl: "" })
+              }
+            >
+              Cancel
+            </Button>
+          )}
+        </div>
+      </form>
+      <ul className="space-y-2">
+        {products.map((product) => (
+          <li
+            key={product.id}
+            className="flex items-center justify-between border p-2 rounded"
+          >
+            <div>
+              <p className="font-semibold">{product.name}</p>
+              <p className="text-sm text-gray-600">{product.price}</p>
+            </div>
+            <div className="space-x-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleEdit(product)}
+              >
+                Edit
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={() => handleDelete(product.id)}
+              >
+                Delete
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,11 +1,18 @@
 /** @format */
 
 "use client";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import ProductCard from "@/components/shared/ProductCard";
-import { MOCK_PRODUCTS } from "../../constants/components";
+import { getProducts } from "@/lib/products";
+import type { Product } from "@/types/components";
 
 export default function MenuPage() {
+  const [products, setProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    getProducts().then(setProducts);
+  }, []);
+
   return (
     <div className="container mx-auto px-4 md:px-6 py-12">
       <h1 className="text-3xl font-bold text-center mb-6 text-gray-900">
@@ -15,7 +22,7 @@ export default function MenuPage() {
         Pilih pempek favorit Anda dan tambahkan ke keranjang.
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
-        {MOCK_PRODUCTS.map((product) => (
+        {products.map((product) => (
           <ProductCard key={product.id} product={product} />
         ))}
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,25 @@
 /** @format */
 
 'use client';
-import {
-  MOCK_PRODUCTS,
-  MOCK_TESTIMONIALS,
-} from '@/constants/components';
+import { MOCK_TESTIMONIALS } from '@/constants/components';
 import { ChevronRightIcon } from 'lucide-react';
 import Link from 'next/link';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import OrderStep from '../components/shared/OrderStep';
 import ProductCard from '../components/shared/ProductCard';
 import TestimonialCard from '../components/shared/TestimonialCard';
 import { Button } from '../components/ui/button';
+import { getProducts } from '@/lib/products';
+import type { Product } from '@/types/components';
 
 export default function HomePage() {
-  const featuredProducts = MOCK_PRODUCTS.slice(0, 4);
+  const [featuredProducts, setFeaturedProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    getProducts().then((products) =>
+      setFeaturedProducts(products.slice(0, 4))
+    );
+  }, []);
 
   return (
     <div className="bg-gray-50 text-gray-800">

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1,0 +1,47 @@
+/** @format */
+
+import {
+  collection,
+  addDoc,
+  getDocs,
+  doc,
+  getDoc,
+  updateDoc,
+  deleteDoc,
+} from 'firebase/firestore';
+import { db } from './firebase';
+import { Product } from '@/types/components';
+
+const productsCol = collection(db, 'products');
+
+export type ProductData = Omit<Product, 'id'>;
+
+export async function getProducts(): Promise<Product[]> {
+  const snapshot = await getDocs(productsCol);
+  return snapshot.docs.map((d) => ({ id: d.id, ...(d.data() as ProductData) }));
+}
+
+export async function getProduct(id: string): Promise<Product | null> {
+  const ref = doc(productsCol, id);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return null;
+  return { id: snap.id, ...(snap.data() as ProductData) };
+}
+
+export async function addProduct(product: ProductData): Promise<string> {
+  const docRef = await addDoc(productsCol, product);
+  return docRef.id;
+}
+
+export async function updateProduct(
+  id: string,
+  product: Partial<ProductData>
+): Promise<void> {
+  const ref = doc(productsCol, id);
+  await updateDoc(ref, product);
+}
+
+export async function deleteProduct(id: string): Promise<void> {
+  const ref = doc(productsCol, id);
+  await deleteDoc(ref);
+}


### PR DESCRIPTION
## Summary
- implement Firestore CRUD helpers for products
- replace mock product data with Firestore fetches on home and menu pages
- add admin interface for creating, editing and deleting products

## Testing
- `npm run lint`
- `npm run build` *(fails: Firebase Error auth/invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_688f19f70148832298e1213542356202