### PR TITLE
feat(navbar): show admin link for admins

### DIFF
--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -48,6 +48,14 @@ const Navbar: React.FC = () => {
               {link.label}
             </Link>
           ))}
+          {user?.role === 'admin' && (
+            <Link
+              href="/admin"
+              className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors"
+            >
+              Admin
+            </Link>
+          )}
         </nav>
         <div className="flex items-center space-x-3">
           <Link


### PR DESCRIPTION
## Summary
- render admin link only when `user.role` is `admin`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f20eb055483229bedaffa9d076b40