### PR TITLE
Fix admin navigation and handle empty data

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,67 @@
+/** @format */
+
+import { addDoc, collection, Timestamp } from 'firebase/firestore';
+import { db } from '../src/lib/firebase';
+
+async function seed() {
+  const products = [
+    {
+      name: 'Pempek Lenjer',
+      description: 'Pempek ikan khas Palembang berbentuk panjang.',
+      price: 15000,
+      imageUrl: 'https://example.com/pempek-lenjer.jpg',
+    },
+    {
+      name: 'Pempek Kapal Selam',
+      description: 'Pempek isi telur rebus yang gurih.',
+      price: 20000,
+      imageUrl: 'https://example.com/pempek-kapal-selam.jpg',
+    },
+  ];
+
+  const productIds: string[] = [];
+  for (const p of products) {
+    const docRef = await addDoc(collection(db, 'products'), p);
+    productIds.push(docRef.id);
+  }
+
+  const order = {
+    items: [
+      {
+        id: productIds[0],
+        name: products[0].name,
+        description: products[0].description,
+        price: products[0].price,
+        imageUrl: products[0].imageUrl,
+        quantity: 2,
+      },
+    ],
+    shippingInfo: {
+      fullName: 'Contoh Customer',
+      phone: '081234567890',
+      address: 'Jl. Demang No. 1',
+      city: 'Palembang',
+      postalCode: '30111',
+    },
+    paymentMethod: {
+      id: 'cod',
+      name: 'Cash On Delivery',
+      type: 'Cash On Delivery',
+    },
+    totalAmount: 2 * products[0].price,
+    status: 'Pending',
+    orderDate: new Date(),
+  };
+
+  await addDoc(collection(db, 'orders'), {
+    ...order,
+    orderDate: Timestamp.fromDate(order.orderDate),
+  });
+
+  console.log('Seeding selesai');
+}
+
+seed().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import Link from "next/link";
 

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -171,18 +171,29 @@ export default function AdminOrdersPage() {
           ))}
         </TableHeader>
         <TableBody>
-          {table.getRowModel().rows.map((row) => (
-            <TableRow key={row.id}>
-              {row.getVisibleCells().map((cell) => (
-                <TableCell key={cell.id}>
-                  {flexRender(
-                    cell.column.columnDef.cell,
-                    cell.getContext()
-                  )}
-                </TableCell>
-              ))}
+          {table.getRowModel().rows.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(
+                      cell.column.columnDef.cell,
+                      cell.getContext()
+                    )}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell
+                colSpan={columns.length}
+                className="text-center"
+              >
+                Data masih kosong
+              </TableCell>
             </TableRow>
-          ))}
+          )}
         </TableBody>
       </Table>
       {pageCount > 1 && (

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -230,18 +230,29 @@ export default function AdminProductsPage() {
           ))}
         </TableHeader>
         <TableBody>
-          {table.getRowModel().rows.map((row) => (
-            <TableRow key={row.id}>
-              {row.getVisibleCells().map((cell) => (
-                <TableCell key={cell.id}>
-                  {flexRender(
-                    cell.column.columnDef.cell,
-                    cell.getContext()
-                  )}
-                </TableCell>
-              ))}
+          {table.getRowModel().rows.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(
+                      cell.column.columnDef.cell,
+                      cell.getContext()
+                    )}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell
+                colSpan={columns.length}
+                className="text-center"
+              >
+                Data masih kosong
+              </TableCell>
             </TableRow>
-          ))}
+          )}
         </TableBody>
       </Table>
       {pageCount > 1 && (


### PR DESCRIPTION
## Summary
- fix navigation between admin pages by making layout a client component
- display "Data masih kosong" when products or orders tables are empty
- add script to seed sample product and order data

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f2bf4ee188322b48db0c445b2db75