### PR TITLE
fix: use server layout for admin navigation

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import Link from "next/link";
 


### PR DESCRIPTION
## Summary
- remove unnecessary `use client` from admin layout to render as server component

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688f2e0bc8b8832287dad4e43df86f8b