### PR TITLE
fix: prevent repeated load on admin pages

### DIFF
--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -38,7 +38,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 const STATUSES: Order['status'][] = [
   'Pending',
@@ -58,7 +58,10 @@ export default function AdminOrdersPage() {
     setOrders(data);
   }, []);
 
+  const initialized = useRef(false);
   useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
     load();
   }, [load]);
 

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -10,7 +10,7 @@ import {
   updateProduct,
 } from '@/lib/products';
 import type { Product } from '@/types/components';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 export default function AdminProductsPage() {
   const [products, setProducts] = useState<Product[]>([]);
@@ -22,14 +22,17 @@ export default function AdminProductsPage() {
     imageUrl: '',
   });
 
-  const load = async () => {
+  const load = React.useCallback(async () => {
     const data = await getProducts();
     setProducts(data);
-  };
-
-  useEffect(() => {
-    load();
   }, []);
+
+  const initialized = useRef(false);
+  useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+    load();
+  }, [load]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- prevent repeated fetch on admin orders by guarding initial load
- avoid multiple load calls on admin products page

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f4a50648483228c3571683ffc1370