### PR TITLE
feat: debounce initial admin data load

### DIFF
--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -38,7 +38,8 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
+import { useDebounceEffect } from '@/hooks/useDebounceEffect';
 
 const STATUSES: Order['status'][] = [
   'Pending',
@@ -58,12 +59,9 @@ export default function AdminOrdersPage() {
     setOrders(data);
   }, []);
 
-  const initialized = useRef(false);
-  useEffect(() => {
-    if (initialized.current) return;
-    initialized.current = true;
+  useDebounceEffect(() => {
     load();
-  }, [load]);
+  }, [load], 300);
 
   const handleStatusChange = React.useCallback(
     async (id: string, status: Order['status']) => {

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -10,7 +10,8 @@ import {
   updateProduct,
 } from '@/lib/products';
 import type { Product } from '@/types/components';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
+import { useDebounceEffect } from '@/hooks/useDebounceEffect';
 
 export default function AdminProductsPage() {
   const [products, setProducts] = useState<Product[]>([]);
@@ -27,12 +28,9 @@ export default function AdminProductsPage() {
     setProducts(data);
   }, []);
 
-  const initialized = useRef(false);
-  useEffect(() => {
-    if (initialized.current) return;
-    initialized.current = true;
+  useDebounceEffect(() => {
     load();
-  }, [load]);
+  }, [load], 300);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/hooks/useDebounceEffect.ts
+++ b/src/hooks/useDebounceEffect.ts
@@ -1,0 +1,21 @@
+/** @format */
+
+import { useEffect, type DependencyList } from 'react';
+
+export function useDebounceEffect(
+  effect: () => void,
+  deps: DependencyList,
+  delay = 300
+) {
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      effect();
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, delay]);
+}
+


### PR DESCRIPTION
## Summary
- add reusable `useDebounceEffect` hook
- debounce initial data load on admin products and orders pages

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688f4da7f7d8832295ee68002ddba515