### PR TITLE
feat: add role-based route middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+
+export async function middleware(req: NextRequest) {
+  const token = await getToken({ req });
+  const { pathname } = req.nextUrl;
+
+  if (pathname.startsWith('/api') || pathname.startsWith('/_next') || pathname === '/favicon.ico') {
+    return NextResponse.next();
+  }
+
+  if (pathname === '/login') {
+    if (token?.role === 'admin') {
+      return NextResponse.redirect(new URL('/admin/orders', req.url));
+    }
+    if (token?.role === 'customer') {
+      return NextResponse.redirect(new URL('/', req.url));
+    }
+    return NextResponse.next();
+  }
+
+  if (pathname.startsWith('/admin')) {
+    if (!token) {
+      return NextResponse.redirect(new URL('/login', req.url));
+    }
+    if (token.role !== 'admin') {
+      return NextResponse.redirect(new URL('/', req.url));
+    }
+    return NextResponse.next();
+  }
+
+  if (token?.role === 'admin') {
+    return NextResponse.redirect(new URL('/admin/orders', req.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+};
+


### PR DESCRIPTION
## Summary
- add middleware to redirect users based on role
- block cross-access between admin and client routes

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f774d80988322a736dc01e2c4b46c